### PR TITLE
Avoid obtaining NaN loss value during training

### DIFF
--- a/pytorch_iou/__init__.py
+++ b/pytorch_iou/__init__.py
@@ -10,7 +10,7 @@ def _iou(pred, target, size_average = True):
     for i in range(0,b):
         #compute the IoU of the foreground
         Iand1 = torch.sum(target[i,:,:,:]*pred[i,:,:,:])
-        Ior1 = torch.sum(target[i,:,:,:]) + torch.sum(pred[i,:,:,:])-Iand1
+        Ior1 = torch.sum(target[i,:,:,:]) + torch.sum(pred[i,:,:,:])-Iand1 + 1e-6
         IoU1 = Iand1/Ior1
 
         #IoU loss is (1-IoU1)


### PR DESCRIPTION
During training for my task where the GT mask might be all zeros, the IOU loss could output NaN due to the divide-by-zero bug. So I suggest adding an eps to avoid this problem.